### PR TITLE
DDF-394 ddf-admin tests now have expected namespace

### DIFF
--- a/core/admin-core-appservice/src/test/java/org/codice/ddf/admin/application/service/impl/ApplicationImplTest.java
+++ b/core/admin-core-appservice/src/test/java/org/codice/ddf/admin/application/service/impl/ApplicationImplTest.java
@@ -12,7 +12,7 @@
  * <http://www.gnu.org/licenses/lgpl.html>.
  *
  **/
-package org.codice.ddf.platform.status.impl;
+package org.codice.ddf.admin.application.service.impl;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -30,7 +30,6 @@ import org.apache.karaf.features.Feature;
 import org.apache.karaf.features.Repository;
 import org.apache.karaf.features.internal.RepositoryImpl;
 import org.codice.ddf.admin.application.service.Application;
-import org.codice.ddf.admin.application.service.impl.ApplicationImpl;
 import org.junit.Test;
 
 /**

--- a/core/admin-core-appservice/src/test/java/org/codice/ddf/admin/application/service/impl/ApplicationNodeImplTest.java
+++ b/core/admin-core-appservice/src/test/java/org/codice/ddf/admin/application/service/impl/ApplicationNodeImplTest.java
@@ -12,7 +12,7 @@
  * <http://www.gnu.org/licenses/lgpl.html>.
  *
  **/
-package org.codice.ddf.platform.status.impl;
+package org.codice.ddf.admin.application.service.impl;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -22,7 +22,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import org.codice.ddf.admin.application.service.Application;
-import org.codice.ddf.admin.application.service.impl.ApplicationNodeImpl;
 import org.junit.Test;
 
 /**

--- a/core/admin-core-appservice/src/test/java/org/codice/ddf/admin/application/service/impl/ApplicationServiceImplTest.java
+++ b/core/admin-core-appservice/src/test/java/org/codice/ddf/admin/application/service/impl/ApplicationServiceImplTest.java
@@ -12,7 +12,7 @@
  * <http://www.gnu.org/licenses/lgpl.html>.
  *
  **/
-package org.codice.ddf.platform.status.impl;
+package org.codice.ddf.admin.application.service.impl;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -38,7 +38,6 @@ import org.codice.ddf.admin.application.service.ApplicationNode;
 import org.codice.ddf.admin.application.service.ApplicationService;
 import org.codice.ddf.admin.application.service.ApplicationStatus;
 import org.codice.ddf.admin.application.service.ApplicationStatus.ApplicationState;
-import org.codice.ddf.admin.application.service.impl.ApplicationServiceImpl;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.osgi.framework.BundleContext;

--- a/core/admin-core-appservice/src/test/java/org/codice/ddf/admin/application/service/impl/ApplicationStatusImplTest.java
+++ b/core/admin-core-appservice/src/test/java/org/codice/ddf/admin/application/service/impl/ApplicationStatusImplTest.java
@@ -12,7 +12,7 @@
  * <http://www.gnu.org/licenses/lgpl.html>.
  *
  **/
-package org.codice.ddf.platform.status.impl;
+package org.codice.ddf.admin.application.service.impl;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -28,7 +28,6 @@ import org.apache.karaf.features.Feature;
 import org.codice.ddf.admin.application.service.Application;
 import org.codice.ddf.admin.application.service.ApplicationStatus;
 import org.codice.ddf.admin.application.service.ApplicationStatus.ApplicationState;
-import org.codice.ddf.admin.application.service.impl.ApplicationStatusImpl;
 import org.junit.Test;
 import org.osgi.framework.Bundle;
 


### PR DESCRIPTION
Names now match source, per https://tools.codice.org/jira/browse/DDF-394
