### PR TITLE
DDF-655 - Fixed Empty Install Profile Issues

### DIFF
--- a/modules/admin-modules-installer/src/main/webapp/js/controllers/InstallerMain.controller.js
+++ b/modules/admin-modules-installer/src/main/webapp/js/controllers/InstallerMain.controller.js
@@ -37,7 +37,7 @@ define([
                         defer.resolve(collection);
                     },
                     failure: function(){
-                        defer.reject("There was an error fetching the installation items.");
+                        defer.reject(new Error("There was an error fetching the installation items."));
                     }
                 });
             }

--- a/modules/admin-modules-installer/src/main/webapp/js/models/Installer.js
+++ b/modules/admin-modules-installer/src/main/webapp/js/models/Installer.js
@@ -50,6 +50,7 @@ define(['backbone', 'underscore', 'jquery'], function (Backbone, _, $) {
             busy: false,
             message: '',
             steps: [],
+            showInstallProfileStep: false,
             selectedProfile: null,
             isCustomProfile: false
         },

--- a/modules/admin-modules-installer/src/main/webapp/js/modules/module.js
+++ b/modules/admin-modules-installer/src/main/webapp/js/modules/module.js
@@ -10,7 +10,7 @@
  *
  **/
 /* jshint unused: false */
-/*global define*/
+/*global define, console */
 define([
     'js/application',
     '/installer/js/views/InstallerMain.view.js',
@@ -22,10 +22,8 @@ define([
     Application.App.module('Installation', function(AppModule, App, Backbone, Marionette, $, _) {
 
         var installerModel = new InstallerModel.Model();
-        //welcome
-        //config
-        //apps
-        installerModel.setTotalSteps(4);
+
+
 
         // Define a view to show
         // ---------------------
@@ -59,7 +57,24 @@ define([
                 region: App.installation
             });
 
-            AppModule.contentController.show();
+            // We determine how many steps we need based on if there are any profiles in the stystem.
+            AppModule.installerMainController.fetchInstallProfiles().then(function(profiles){
+                if(profiles.isEmpty()){
+                    installerModel.set('showInstallProfileStep', false);
+                    installerModel.setTotalSteps(3);
+                } else {
+                    installerModel.set('showInstallProfileStep', true);
+                    installerModel.setTotalSteps(4);
+                }
+            }).fail(function(error){
+                // fallback: just don't show the install profile steps.
+                installerModel.set('showInstallProfileStep', false);
+                installerModel.setTotalSteps(3);
+                console.log(error);
+            }).done(function(){
+                // regardless of success, lets display the page.
+                AppModule.contentController.show();
+            });
         });
     });
 });

--- a/modules/admin-modules-installer/src/main/webapp/js/modules/module.js
+++ b/modules/admin-modules-installer/src/main/webapp/js/modules/module.js
@@ -70,7 +70,9 @@ define([
                 // fallback: just don't show the install profile steps.
                 installerModel.set('showInstallProfileStep', false);
                 installerModel.setTotalSteps(3);
-                console.log(error);
+                if(console){
+                    console.log(error);
+                }
             }).done(function(){
                 // regardless of success, lets display the page.
                 AppModule.contentController.show();

--- a/modules/admin-modules-installer/src/main/webapp/js/views/Application.view.js
+++ b/modules/admin-modules-installer/src/main/webapp/js/views/Application.view.js
@@ -62,7 +62,9 @@ define([
                     }
                     self.applications.show(appView);
                 }).fail(function(error){
-                    console.log(error);
+                    if(console){
+                        console.log(error);
+                    }
                 });
 
             },

--- a/modules/admin-modules-installer/src/main/webapp/js/views/Application.view.js
+++ b/modules/admin-modules-installer/src/main/webapp/js/views/Application.view.js
@@ -52,12 +52,17 @@ define([
                     var profileKey = self.navigationModel.get('selectedProfile');
                     var selectedProfile = profiles.findWhere({name: profileKey});
                     var appView  = new AppView({selectedProfile: selectedProfile, modelClass: self.modelClass, showAddUpgradeBtn: false});
-                    self.listenToOnce(appView, 'collection:loaded', function(){
-                        if(!self.navigationModel.get('isCustomProfile')){
-                            self.navigationModel.trigger('next'); // force next step... which will trigger the apps to be installed.
-                        }
-                    });
+                    if(selectedProfile){
+                        self.listenToOnce(appView, 'collection:loaded', function(){
+                            if(!self.navigationModel.get('isCustomProfile')){
+                                //if a profile is selected and the customized is not used, we automatically install the apps.
+                                self.navigationModel.trigger('next'); // force next step... which will trigger the apps to be installed.
+                            }
+                        });
+                    }
                     self.applications.show(appView);
+                }).fail(function(error){
+                    console.log(error);
                 });
 
             },

--- a/modules/admin-modules-installer/src/main/webapp/js/views/InstallerMain.view.js
+++ b/modules/admin-modules-installer/src/main/webapp/js/views/InstallerMain.view.js
@@ -139,7 +139,9 @@ define([
                         collection: profiles
                     }));
                 }).fail(function(error){
-                    console.log(error);
+                    if(console){
+                        console.log(error);
+                    }
                 }).done();
             }
             this.$(this.profiles.el).show();

--- a/modules/admin-modules-installer/src/main/webapp/js/views/InstallerMain.view.js
+++ b/modules/admin-modules-installer/src/main/webapp/js/views/InstallerMain.view.js
@@ -49,31 +49,43 @@ define([
         },
         changePage: function() {
             //close whatever view is open
-            if(this.welcome.currentView && this.model.get('stepNumber') !== 0) {
+            var welcomeStep = 0, configStep = 1, profileStep = null, applicationStep = null, finishStep = null;
+            if(this.model.get('showInstallProfileStep')){
+                // factor in profile step
+                profileStep = 2;
+                applicationStep = 3;
+                finishStep = 4;
+            } else {
+                // no profile step.
+                profileStep = null;
+                applicationStep = 2;
+                finishStep = 3;
+            }
+            if(this.welcome.currentView && this.model.get('stepNumber') !== welcomeStep) {
                 this.hideWelcome();
             }
-            if(this.configuration.currentView && this.model.get('stepNumber') !== 1) {
+            if(this.configuration.currentView && this.model.get('stepNumber') !== configStep) {
                 this.hideConfiguration();
             }
-            if(this.profiles.currentView && this.model.get('stepNumber') !== 2) {
+            if(this.profiles.currentView && this.model.get('stepNumber') !== profileStep) {
                 this.hideProfiles();
             }
-            if(this.applications.currentView && this.model.get('stepNumber') !== 3) {
+            if(this.applications.currentView && this.model.get('stepNumber') !== applicationStep) {
                 this.hideApplications();
             }
-            if(this.finish.currentView && this.model.get('stepNumber') !== 4) {
+            if(this.finish.currentView && this.model.get('stepNumber') !== finishStep) {
                 this.hideFinish();
             }
             //show the next or previous view
-            if(!this.welcome.currentView && this.model.get('stepNumber') <= 0) {
+            if(!this.welcome.currentView && this.model.get('stepNumber') <= welcomeStep) {
                 this.showWelcome();
-            } else if(!this.configuration.currentView && this.model.get('stepNumber') === 1) {
+            } else if(!this.configuration.currentView && this.model.get('stepNumber') === configStep) {
                 this.showConfiguration();
-            } else if(!this.profiles.currentView && this.model.get('stepNumber') === 2) {
+            } else  if(!this.profiles.currentView && this.model.get('stepNumber') === profileStep) {
                 this.showProfiles();
-            } else if(!this.applications.currentView && this.model.get('stepNumber') === 3) {
+            } else if(!this.applications.currentView && this.model.get('stepNumber') === applicationStep) {
                 this.showApplications();
-            } else if(!this.finish.currentView && this.model.get('stepNumber') >= 4) {
+            } else if(!this.finish.currentView && this.model.get('stepNumber') >= finishStep) {
                 this.showFinish();
             }
         },
@@ -117,7 +129,7 @@ define([
                 Application.App.submodules.Installation.installerMainController.fetchInstallProfiles().then(function(profiles){
                     // set initial selected profile if null.
                     var profileKey = self.model.get('selectedProfile');
-                    if(!profileKey){
+                    if(!profileKey && !profiles.isEmpty()){
                         profileKey = profiles.first().get('name');
                         self.model.set('selectedProfile',profileKey);
                     }
@@ -126,7 +138,9 @@ define([
                         navigationModel: self.model,
                         collection: profiles
                     }));
-                });
+                }).fail(function(error){
+                    console.log(error);
+                }).done();
             }
             this.$(this.profiles.el).show();
         },

--- a/modules/admin-modules-installer/src/main/webapp/templates/profile.handlebars
+++ b/modules/admin-modules-installer/src/main/webapp/templates/profile.handlebars
@@ -14,28 +14,34 @@
 <h3>Installation Profiles</h3>
 
 <div class="well white">
-    <p class="lead">Choose an application install profile.</p>
-
-    <div class="profile-options scroll-area ps-container">
-        {{#profiles}}
-            <div class="profile-option clearfix">
-                <div class="pull-left">
-                    <div class="cell">
-                        <input type="radio" name="selectedProfile" value="{{name}}" />
+    {{#if profiles}}
+        <p class="lead">Choose an application install profile.</p>
+        <div class="profile-options scroll-area ps-container">
+            {{#profiles}}
+                <div class="profile-option clearfix">
+                    <div class="pull-left">
+                        <div class="cell">
+                            <input type="radio" name="selectedProfile" value="{{name}}" />
+                        </div>
+                        <div class="cell">
+                            <h2 class="">{{displayName}}</h2>
+                            <p>{{description}}</p>
+                        </div>
                     </div>
-                    <div class="cell">
-                        <h2 class="">{{displayName}}</h2>
-                        <p>{{description}}</p>
+                    <div class="pull-right">
+                        <div class="cell">
+                            <button type="checkbox" class="btn customize" name="isCustomProfile"><i class="fa fa-check"></i> Customize</button>
+                        </div>
                     </div>
                 </div>
-                <div class="pull-right">
-                    <div class="cell">
-                        <button type="checkbox" class="btn customize" name="isCustomProfile"><i class="fa fa-check"></i> Customize</button>
-                    </div>
-                </div>
-            </div>
-        {{/profiles}}
-    </div>
-
-
+            {{/profiles}}
+        </div>
+    {{else}}
+        <p class="lead">
+            No Installation Profiles are configured on the system.
+            <br/>
+            <br/>
+            Click next to proceed to Application Customization.
+        </p>
+    {{/if}}
 </div>


### PR DESCRIPTION
Added some q.fail() to the promise chains.  Js errors were getting eaten up by the q.promise.

Also added logic to profile template to show an empty profile list message.

UPDATE: adjusted the installer app to hide the install profile step if no profiles are present.
