### PR TITLE
DDF-741

### DIFF
--- a/core/admin-core-appservice/pom.xml
+++ b/core/admin-core-appservice/pom.xml
@@ -24,11 +24,6 @@
   <description>Exposes and application service that allows operations on DDF applications.</description>
   <packaging>bundle</packaging>
 
-  <properties>
-    <!-- UPDATE VERSION EACH TIME INTERFACE CHANGES -->
-    <admin.core.appservice.api.version>1.0.0</admin.core.appservice.api.version>
-  </properties>
-
   <dependencies>
     <dependency>
         <groupId>org.apache.servicemix.specs</groupId>
@@ -93,8 +88,8 @@
               *
             </Import-Package>
             <Export-Package>
-            	org.codice.ddf.admin.application.service;version=${admin.core.appservice.api.version},
-            	org.codice.ddf.admin.application.plugin;version=${admin.core.appservice.api.version}
+            	org.codice.ddf.admin.application.service;version=${project.version},
+            	org.codice.ddf.admin.application.plugin;version=${project.version}
             </Export-Package>
           </instructions>
         </configuration>


### PR DESCRIPTION
fixed Export-Package issue with 3rd party libraries using appservices packages.

When ApplictionPlugin interface was changed, other applications were not picking up the changes correctly.  Changed the Export-Package version to match the project's version.
