### PR TITLE
DDF-706

### DIFF
--- a/core/admin-core-appservice/src/main/java/org/codice/ddf/admin/application/plugin/AbstractApplicationPlugin.java
+++ b/core/admin-core-appservice/src/main/java/org/codice/ddf/admin/application/plugin/AbstractApplicationPlugin.java
@@ -30,14 +30,10 @@ public class AbstractApplicationPlugin implements ApplicationPlugin {
 	protected String displayName = null;
 	/** the location of the iframe. Protected so implementers can set this.*/
 	protected URI iframeLocation = null;
-	/** the location of the javascript. Protected so implements can set this.*/
-	protected URI javascriptLocation = null;
 	/** The id of this plugin.*/
 	private UUID id = UUID.randomUUID();
 	/** the application name. Protected so implementers can set this.*/
 	private List<String> assocations = new ArrayList<String>();
-	/** the order of this plugin. Protected so implements can set this.*/
-	protected Integer order = Integer.MAX_VALUE;
 	
 	/**
 	 * Constructor.
@@ -57,15 +53,6 @@ public class AbstractApplicationPlugin implements ApplicationPlugin {
 	public String getDisplayName() {
 		return this.displayName;
 	}
-	
-	/** {@inheritDoc}.*/
-	@Override
-	public String getJavascriptLocation() {
-		if (this.javascriptLocation == null) {
-			return null;
-		}
-		return this.javascriptLocation.toString();
-	}
 
 	/** {@inheritDoc}.*/
 	@Override
@@ -78,12 +65,6 @@ public class AbstractApplicationPlugin implements ApplicationPlugin {
 	
 	/** {@inheritDoc}.*/
 	@Override
-	public Integer getOrder() {
-		return this.order;
-	}
-	
-	/** {@inheritDoc}.*/
-	@Override
 	public Map<String, Object> toJSON() {
 		Map<String, Object> jsonMapping = new HashMap<String, Object>();
 		
@@ -91,8 +72,6 @@ public class AbstractApplicationPlugin implements ApplicationPlugin {
 		jsonMapping.put(ApplicationPlugin.ID_KEY, this.id.toString());
 		jsonMapping.put(ApplicationPlugin.DISPLAY_NAME_KEY, this.displayName);
 		jsonMapping.put(ApplicationPlugin.IFRAME_LOCATION_KEY, (this.iframeLocation == null) ? null : this.iframeLocation.toString());
-		jsonMapping.put(ApplicationPlugin.JAVASCRIPT_LOCATION_KEY, (this.javascriptLocation == null) ? null : this.javascriptLocation.toString());
-		jsonMapping.put(ApplicationPlugin.ORDER_KEY, this.order);
 		
 		return jsonMapping;
 	}

--- a/core/admin-core-appservice/src/main/java/org/codice/ddf/admin/application/plugin/ApplicationPlugin.java
+++ b/core/admin-core-appservice/src/main/java/org/codice/ddf/admin/application/plugin/ApplicationPlugin.java
@@ -31,13 +31,9 @@ public interface ApplicationPlugin {
 	public static final String APPLICATION_ASSOCIATION_KEY = "applicationAssociation";
 	/** key for the iframe location. Used for creating json.*/
 	public static final String IFRAME_LOCATION_KEY = "iframeLocation";
-	/** key for the javascript location. Used for creating json.*/
-	public static final String JAVASCRIPT_LOCATION_KEY = "javascriptLocation";
 	/** key for the id location. Used for creating json.*/
 	public static final String ID_KEY = "id";
-	/** key for the order. Used for creating json.*/
-	public static final String ORDER_KEY = "order";
-	
+
 	/**
 	 * Returns a list of applications that this plugin should be associated with.
 	 * @return a list of applications that this plugin should be associated with.
@@ -57,24 +53,10 @@ public interface ApplicationPlugin {
 	public UUID getID();
 	
 	/**
-	 * Returns the location of the javascript. Can be null.
-	 * @return the location of the javascript.
-	 */
-	public String getJavascriptLocation();
-	
-	/**
 	 * Returns the iframe location. Can be null.
 	 * @return the iframe location.
 	 */
     public String getIframeLocation();
-    
-    /**
-     * Returns the prefered order. This value can be duplicated between plugins, at which
-     * point the front end will use the name of the plugin to sort those of the same order
-     * number.
-     * @return the order of how this plugin should be displayed.
-     */
-    public Integer getOrder();
     
     /**
      * Utility method that will handle the conversion of this object to something

--- a/core/admin-core-appservice/src/test/java/org/codice/ddf/admin/application/plugin/ApplicationConfigurationPluginTest.java
+++ b/core/admin-core-appservice/src/test/java/org/codice/ddf/admin/application/plugin/ApplicationConfigurationPluginTest.java
@@ -31,7 +31,6 @@ import org.junit.Test;
 
 /**
  * Handles testing the different aspects of the applicationconfiguraitonplugin.
- * @author Jeren
  *
  */
 public class ApplicationConfigurationPluginTest {
@@ -45,13 +44,9 @@ public class ApplicationConfigurationPluginTest {
 	private static final String TEST_ASSOCATION_2 = "Test2";
 	/** static for the assocations test.*/
 	private static final List<String> ORIGINAL_APP_ASSOCIATIONS = new LinkedList<String>(Arrays.asList(TEST_ASSOCATION_1, TEST_ASSOCATION_2));
-	
-	private static final Integer ORDER_TEST = 1337;
-	
 
 	/**
 	 * Test class we will utilize for the tests.
-	 * @author Jeren
 	 *
 	 */
 	private class TestPlugin extends AbstractApplicationPlugin {
@@ -61,7 +56,6 @@ public class ApplicationConfigurationPluginTest {
 		public TestPlugin() {
 			this.displayName = DISPLAY_NAME_TEST;
 			this.iframeLocation = URI.create(IFRAME_LOCATION_TEST);
-			this.order = ORDER_TEST;
 			setAssociations(ORIGINAL_APP_ASSOCIATIONS);
 		}
 		
@@ -80,15 +74,12 @@ public class ApplicationConfigurationPluginTest {
 		assertFalse(0 == plugin.getID().compareTo(plugin2.getID()));
 		assertEquals(plugin.getIframeLocation().toString(), IFRAME_LOCATION_TEST);
 		assertEquals(plugin.getAssocations(), ORIGINAL_APP_ASSOCIATIONS);
-		assertEquals(plugin.getOrder(), ORDER_TEST);
 		
 		Map<String, Object> constructedJSON = new HashMap<String, Object>();
 		constructedJSON.put(ApplicationPlugin.DISPLAY_NAME_KEY, plugin.getDisplayName());
 		constructedJSON.put(ApplicationPlugin.ID_KEY, plugin.getID().toString());
 		constructedJSON.put(ApplicationPlugin.IFRAME_LOCATION_KEY, plugin.getIframeLocation());
-		constructedJSON.put(ApplicationPlugin.JAVASCRIPT_LOCATION_KEY, plugin.getJavascriptLocation());
 		constructedJSON.put(ApplicationPlugin.APPLICATION_ASSOCIATION_KEY, plugin.getAssocations());
-		constructedJSON.put(ApplicationPlugin.ORDER_KEY, plugin.getOrder());
 		
 		//compare the maps.
 		Map<String, Object> pluginMap = plugin.toJSON();

--- a/ui/src/main/webapp/js/controllers/AppDetail.controller.js
+++ b/ui/src/main/webapp/js/controllers/AppDetail.controller.js
@@ -40,25 +40,40 @@ define([
                     new Backbone.Model({
                         'id': 'detailsApplicationTabID',
                         'displayName': 'Details',
-                        'javascriptLocation': 'js/views/application/plugins/details/Plugin.view.js',
-                        'order': 0
+                        'javascriptLocation': 'js/views/application/plugins/details/Plugin.view.js'
                     }),
                     new Backbone.Model({
                         'id': 'featuresApplicationTabID',
                         'displayName': 'Features',
-                        'javascriptLocation': 'js/views/application/plugins/features/Plugin.view.js',
-                        'order': 1
+                        'javascriptLocation': 'js/views/application/plugins/features/Plugin.view.js'
                     }),
                     new Backbone.Model({
                         'id': 'configurationApplicationTabID',
                         'displayName': 'Configuration',
-                        'javascriptLocation': 'js/views/application/plugins/config/Plugin.view.js',
-                        'order': 2
+                        'javascriptLocation': 'js/views/application/plugins/config/Plugin.view.js'
                     })
                 ];
-                appConfigPlugins.add(staticApplicationPlugins);
-                layoutView.tabs.show(new PluginTabView({collection: appConfigPlugins, model: applicationModel}));
-                layoutView.tabContent.show(new PluginTabContentView({collection: appConfigPlugins, model: applicationModel}));
+
+                var staticList = new Backbone.Collection();
+                staticList.comparator = function(model) {
+                    return model.get('displayName');
+                };
+                staticList.add(staticApplicationPlugins);
+                staticList.sort();
+
+                var dynamicList = new Backbone.Collection();
+                dynamicList.comparator = function(model) {
+                    return model.get('displayName');
+                };
+                dynamicList.add(appConfigPlugins.models);
+                dynamicList.sort();
+
+                var completeList = new Backbone.Collection();
+                completeList.add(dynamicList.models);
+                completeList.add(staticList.models);
+
+                layoutView.tabs.show(new PluginTabView({collection: completeList, model: applicationModel}));
+                layoutView.tabContent.show(new PluginTabContentView({collection: completeList, model: applicationModel}));
                 layoutView.selectFirstTab();
             }).fail(function(error){
                 throw error;

--- a/ui/src/main/webapp/js/controllers/ModuleDetail.controller.js
+++ b/ui/src/main/webapp/js/controllers/ModuleDetail.controller.js
@@ -50,7 +50,11 @@ define([
             ];
 
             var collection = new ModulePlugin.Collection();
+            collection.comparator = function(model) {
+                return model.get('displayName');
+            };
             collection.add(staticModulePlugins);
+            collection.sort();
 
             layoutView.tabs.show(new PluginTabView({collection: collection}));
             layoutView.tabContent.show(new PluginTabContentView({collection: collection}));

--- a/ui/src/main/webapp/js/models/AppConfigPlugin.js
+++ b/ui/src/main/webapp/js/models/AppConfigPlugin.js
@@ -36,20 +36,6 @@ define([
         },
         parse: function(resp){
             return resp.value;
-        },
-        comparator: function(model){
-            var secondary = null;
-            var displayName = model.get("displayName");
-            if(displayName === 'Details'){
-                secondary = 0;
-            } else if(displayName === 'Features'){
-                secondary = 1;
-            } else if(displayName === 'Configurations'){
-                secondary = 2;
-            } else {
-                secondary = 4;
-            }
-            return [model.get("order"), secondary];
         }
     });
 


### PR DESCRIPTION
Updating the ordering for plugins. Now static plugins will appear to the right most, ordered by name amongst themselves. Dynamic plugins are loaded to the left most, ordered by name amongst themselves.

Removing jsLocation member variable for the backend. Can't create a new plugin that has it. Static plugins can use it still for the front end.
