### PR TITLE
DDF-818 - fixed template render bug for configurationItem template.

### DIFF
--- a/ui/src/main/webapp/js/views/configuration/ConfigurationEdit.view.js
+++ b/ui/src/main/webapp/js/views/configuration/ConfigurationEdit.view.js
@@ -28,17 +28,16 @@ define([
 	
     var ConfigurationEditView = {};
 
-
-    if(!ich.configurationItem) {
+    if(!ich['configuration.configurationItem']) {
         ich.addTemplate('configuration.configurationItem', configurationItem);
     }
-    if(!ich.configurationEdit) {
+    if(!ich['configuration.configurationEdit']) {
         ich.addTemplate('configuration.configurationEdit', configurationEdit);
     }
-    if(!ich.textTypeListHeader) {
+    if(!ich['configuration.textTypeListHeader']) {
         ich.addTemplate('configuration.textTypeListHeader', textTypeListHeader);
     }
-    if(!ich.textTypeList) {
+    if(!ich['configuration.textTypeList']) {
         ich.addTemplate('configuration.textTypeList', textTypeList);
     }
 


### PR DESCRIPTION
-This bug only happens when the Installer Module is installed with either the configuration or the application module.  There is a collision of  "configurationEdit" vs "configuration.configurationEdit" template bindings happening on different views on the page.  I just updated the if statements to check the right values.
