### PR TITLE
DDF-900 Fixing model binder removing values of configuration lists

### DIFF
--- a/ui/src/main/webapp/js/views/configuration/ConfigurationEdit.view.js
+++ b/ui/src/main/webapp/js/views/configuration/ConfigurationEdit.view.js
@@ -218,6 +218,8 @@ define([
         bind: function() {
             var view = this;
             var bindings = Backbone.ModelBinder.createDefaultBindings(this.el, 'name');
+            //this is done so that model binder wont watch these values. We need to handle this ourselves.
+            delete bindings.value;
             var bindObjs = _.values(bindings);
             _.each(bindObjs, function(value) {
                 if(view.$(value.selector).attr('type') === 'checkbox') {


### PR DESCRIPTION
Fixing an issue where model binder was removing the values of a configuration list. This was done because it is confused to the values it's watching. Removed model binder from watching the list and then set up the handling ourselves.
