### PR TITLE
DDF-903 - Removed the es5 option from the jshint to expose es3 (older browser) warnings/errors

### DIFF
--- a/ui/Gruntfile.js
+++ b/ui/Gruntfile.js
@@ -54,12 +54,12 @@ module.exports = function (grunt) {
 
                 // Relaxing Options
                 scripturl: true,      // This option suppresses warnings about the use of script-targeted URLsâ€”such as
-                es5: true,             // Tells JSHint that your code uses ECMAScript 5 specific features such as getters and setters.
 
                 // options here to override JSHint defaults
                 globals: {
                     console: true,
-                    module: true
+                    module: true,
+                    define: true
                 }
             }
         },

--- a/ui/src/main/webapp/index.html
+++ b/ui/src/main/webapp/index.html
@@ -18,6 +18,7 @@
 <html>
     <head>
         <title>Admin Console</title>
+        <meta http-equiv="x-ua-compatible" content="IE=Edge"/>
         <!-- Stylesheets -->
         <link href="lib/components-font-awesome/css/font-awesome.min.css" rel="stylesheet"/>
         <link href="lib/bootswatch/flatly/bootstrap.min.css" rel="stylesheet"/>

--- a/ui/src/main/webapp/js/models/Applications.js
+++ b/ui/src/main/webapp/js/models/Applications.js
@@ -334,7 +334,7 @@ define([
                     childModel.setSelectedBasedOnProfile(installProfile);
                 });
             }
-        },
+        }
 
     });
 

--- a/ui/src/main/webapp/js/models/Module.js
+++ b/ui/src/main/webapp/js/models/Module.js
@@ -26,7 +26,7 @@ define([
                 key: 'value',
                 relatedModel: module,
                 collectionType: moduleCollection,
-                includeInJSON: false,
+                includeInJSON: false
             }
         ]
     });

--- a/ui/src/main/webapp/js/models/Service.js
+++ b/ui/src/main/webapp/js/models/Service.js
@@ -13,6 +13,7 @@
  *
  **/
 /*global define*/
+/* jshint -W024*/
 define(['backbone', 'jquery','backboneassociations'],function (Backbone, $) {
 
 

--- a/ui/src/main/webapp/js/modules/Installer.module.js
+++ b/ui/src/main/webapp/js/modules/Installer.module.js
@@ -15,7 +15,7 @@ define([
     'js/application',
     'js/views/installer/InstallerMain.view',
     'js/models/Installer',
-    'js/controllers/InstallerMain.controller',
+    'js/controllers/InstallerMain.controller'
     ], function(Application, InstallerMainView, InstallerModel, InstallerMainController) {
 
     Application.App.module('Installation', function(AppModule, App, Backbone, Marionette, $, _) {

--- a/ui/src/main/webapp/js/views/application/Application.view.js
+++ b/ui/src/main/webapp/js/views/application/Application.view.js
@@ -13,6 +13,7 @@
  *
  **/
 /*global define*/
+/* jshint -W024*/
 /** Main view page for add. **/
 define([
     'require',

--- a/ui/src/main/webapp/js/views/application/ApplicationGrid.view.js
+++ b/ui/src/main/webapp/js/views/application/ApplicationGrid.view.js
@@ -13,6 +13,7 @@
  *
  **/
 /*global define*/
+/* jshint -W024*/
 /** Main view page for add. **/
 define([
     'require',

--- a/ui/src/main/webapp/js/views/application/application-detail/PluginTab.view.js
+++ b/ui/src/main/webapp/js/views/application/application-detail/PluginTab.view.js
@@ -18,7 +18,7 @@ define([
     'icanhaz',
     'text!pluginTabItemView',
     'text!pluginTabCollectionView',
-    'js/wreqr.js',
+    'js/wreqr.js'
     ],function (Marionette, ich, pluginTabItemView, pluginTabCollectionView, wreqr) {
 
     ich.addTemplate('pluginTabItemView',pluginTabItemView);

--- a/ui/src/main/webapp/js/views/application/features/features.view.js
+++ b/ui/src/main/webapp/js/views/application/features/features.view.js
@@ -43,7 +43,7 @@ define([
                 };
 
                 return returnValue;
-            },
+            }
         });
 
         return FeaturesView;

--- a/ui/src/main/webapp/js/views/installer/Configuration.view.js
+++ b/ui/src/main/webapp/js/views/installer/Configuration.view.js
@@ -91,7 +91,7 @@ define([
                 return view;
             }
             return new Marionette.ItemView();
-        },
+        }
     });
 
     var validateFunction = function(attrs) {


### PR DESCRIPTION
-Removed the es5 option from the jshint configuration.  This will expose IE8/IE9 issues like trailing commas.
-Once I turned off es5, other errors cropped up so I fixed those where I could.
