### PR TITLE
DDF-922 Add empty views to display messages for tabs inside the admin UI...

### DIFF
--- a/ui/src/main/webapp/js/controllers/Feature.controller.js
+++ b/ui/src/main/webapp/js/controllers/Feature.controller.js
@@ -17,8 +17,9 @@ define([
         'marionette',
         'underscore',
         'js/views/application/features/features.view',
+        'js/views/EmptyView',
         'js/models/features/feature'
-    ], function(Marionette, _, FeaturesView, FeatureModel){
+    ], function(Marionette, _, FeaturesView, EmptyView, FeatureModel){
         "use strict";
 
         var FeatureController = Marionette.Controller.extend({
@@ -36,7 +37,7 @@ define([
                 });
                 features.fetch({
                     success: function(collection) {
-                        var featureView = new FeaturesView({
+                        var featureView = self.getFeatureView({
                             collection: collection
                         });
                         self.region.show(featureView);
@@ -54,7 +55,7 @@ define([
                 });
                 features.fetch({
                     success: function(collection) {
-                        var featureView = new FeaturesView({
+                        var featureView = self.getFeatureView({
                             collection: collection
                         });
                         self.region.show(featureView);
@@ -70,7 +71,7 @@ define([
                 });
                 features.fetch({
                     success: function(collection) {
-                        var featureView = new FeaturesView({
+                        var featureView = view.getFeatureView({
                             collection: collection,
                             showWarnings: true
                         });
@@ -78,6 +79,14 @@ define([
                     }
                 });
             },
+
+            getFeatureView: function(options) {
+                if (options.collection && options.collection.length) {
+                    return new FeaturesView(options);
+                }
+                return new EmptyView.view({message: 'No features are available for the "' + this.appName + '" application.'});
+            },
+
             onFeatureAction: function (view, model){
                 var self = this;
                 var status = model.get("status");

--- a/ui/src/main/webapp/js/models/Service.js
+++ b/ui/src/main/webapp/js/models/Service.js
@@ -171,7 +171,7 @@ define(['backbone', 'jquery','backboneassociations'],function (Backbone, $) {
 
         defaults: {
             configurations: new Service.ConfigurationList()
-        },
+        }, 
 
 
         relations: [
@@ -186,6 +186,7 @@ define(['backbone', 'jquery','backboneassociations'],function (Backbone, $) {
                 type: Backbone.Many,
                 key: 'metatype',
                 relatedModel: Service.Metatype,
+                collectionType: Service.MetatypeList,
                 includeInJSON: false
             }
         ],

--- a/ui/src/main/webapp/js/views/EmptyView.js
+++ b/ui/src/main/webapp/js/views/EmptyView.js
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+/*global define*/
+define([
+    'marionette',
+    'text!templates/emptyView.handlebars',
+    'icanhaz'
+],
+function (Marionette, emptyViewTemplate, ich) {
+
+    ich.addTemplate('emptyViewTemplate', emptyViewTemplate);
+
+    var EmptyView = {};
+
+    EmptyView.view = Marionette.ItemView.extend({
+        template: 'emptyViewTemplate',
+        initialize: function(options) {
+            this.message = options.message;
+        },
+        serializeData: function() {
+            return  {message: this.message};
+        }
+    });
+
+    EmptyView.services = Marionette.ItemView.extend({
+        template: 'emptyViewTemplate',
+        serializeData: function() {
+            return  {message: "There are no services currently configured."};
+        }
+    });
+
+    return EmptyView;
+});

--- a/ui/src/main/webapp/js/views/application/features/features.view.js
+++ b/ui/src/main/webapp/js/views/application/features/features.view.js
@@ -15,13 +15,13 @@
 /*global define*/
 define([
         'marionette',
+        'icanhaz',
         'underscore',
         'jquery',
         './featureRow.view',
-        'text!featureTemplate',
-        'icanhaz'
+        'text!featureTemplate'
 ],
-    function(Marionette, _, $, FeatureRowView, FeaturesTemplate, ich){
+    function(Marionette, ich, _, $, FeatureRowView, FeaturesTemplate){
         'use strict';
 
         if(!ich.featureTemplate) {

--- a/ui/src/main/webapp/js/views/configuration/ConfigurationEdit.view.js
+++ b/ui/src/main/webapp/js/views/configuration/ConfigurationEdit.view.js
@@ -114,7 +114,7 @@ define([
         saveValues: function() {
             var values = [];
             _.each(this.collectionArray.models, function(model) {
-                values.push(model.get('value'));                
+                values.push(model.get('value'));
             });
             this.configuration.get('properties').set(this.model.get('id'), values.join());
         },

--- a/ui/src/main/webapp/js/views/configuration/Service.view.js
+++ b/ui/src/main/webapp/js/views/configuration/Service.view.js
@@ -19,13 +19,14 @@ define([
     'marionette',
     'js/models/Service',
     './ConfigurationEdit.view',
+    'js/views/EmptyView',
     'js/wreqr.js',
     'text!templates/configuration/serviceList.handlebars',
     'text!templates/configuration/serviceRow.handlebars',
     'text!templates/configuration/configurationRow.handlebars',
     'text!templates/configuration/servicePage.handlebars',
     'text!templates/configuration/configurationList.handlebars'
-    ],function (ich, _, Marionette, Service, ConfigurationEdit, wreqr, serviceList, serviceRow, configurationRow, servicePage, configurationList) {
+    ],function (ich, _, Marionette, Service, ConfigurationEdit, EmptyView, wreqr, serviceList, serviceRow, configurationRow, servicePage, configurationList) {
 
     var ServiceView = {};
 
@@ -99,6 +100,7 @@ define([
         template: 'serviceList',
         itemView: ServiceView.ServiceRow,
         itemViewContainer: 'tbody',
+        emptyView: EmptyView.services,
 
         initialize: function(options) {
             this.showWarnings = options.showWarnings;
@@ -145,8 +147,8 @@ define([
                 return model.get('name');
             };
 
-            this.model.get("value").sort();
-            this.collectionRegion.show(new ServiceView.ServiceTable({ collection: this.model.get("value"), showWarnings: this.showWarnings }));
+            var collection = this.model.get("value").sort();
+            this.collectionRegion.show(new ServiceView.ServiceTable({ collection: collection, showWarnings: this.showWarnings }));
         },
         refreshServices: function() {
             wreqr.vent.trigger('refreshConfigurations');

--- a/ui/src/main/webapp/less/configuration/style.less
+++ b/ui/src/main/webapp/less/configuration/style.less
@@ -71,6 +71,15 @@
   }
 }
 
+.no-results {
+  height: 100px;
+  display: table;
+  .message {
+    display: table-cell;
+    vertical-align: middle;
+  }
+}
+
 .service-row-table > tbody > tr > td {
     padding: 4px 0px 4px 0px;
 

--- a/ui/src/main/webapp/templates/emptyView.handlebars
+++ b/ui/src/main/webapp/templates/emptyView.handlebars
@@ -1,0 +1,18 @@
+{{!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+ --}}
+ <div class="no-results">
+    <div class="message">
+        {{message}}
+    </div>
+</div>


### PR DESCRIPTION
- The tabs that may have empty list data are features, services and federated sources
- Added an EmptyView that can be used to display unique messages for each tab.
