### PR TITLE
DDF-939 - Added optional banners to admin ui

### DIFF
--- a/ui/src/main/webapp/index.html
+++ b/ui/src/main/webapp/index.html
@@ -34,13 +34,15 @@
     </head>
     <body>
         <header></header>
-        <div id="appHeader">
+        <div class="main-content">
+            <div id="appHeader">
 
+            </div>
+            <div class="container">
+                <!--<h2 id="pageHeader"></h2>-->
+            </div>
+            <main class="container" role="main"></main>
         </div>
-        <div class="container">
-            <!--<h2 id="pageHeader"></h2>-->
-        </div>
-        <main class="container" role="main"></main>
         <footer></footer>
 
     </body>

--- a/ui/src/main/webapp/less/common/banner.less
+++ b/ui/src/main/webapp/less/common/banner.less
@@ -1,0 +1,33 @@
+html.has-header {
+  header {
+    position: fixed;
+    top: 0px;
+    right: 0px;
+    left: 0px;
+    height: 20px;
+    text-align: center;
+    z-index: 2;  // higher than .main-content
+  }
+
+  .main-content {
+    padding-top: 20px;
+    z-index: 1;
+  }
+}
+
+html.has-footer {
+  footer {
+    position: fixed;
+    bottom: 0px;
+    right: 0px;
+    left: 0px;
+    height: 20px;
+    text-align: center;
+    z-index: 2; // higher than .main-content
+  }
+
+  .main-content {
+    padding-bottom: 20px;
+    z-index: 1;
+  }
+}

--- a/ui/src/main/webapp/less/common/init.less
+++ b/ui/src/main/webapp/less/common/init.less
@@ -1,3 +1,4 @@
 @import "loading-overlay.less";
 @import "wells.less";
 @import "tables.less";
+@import "banner.less";

--- a/ui/src/main/webapp/main.js
+++ b/ui/src/main/webapp/main.js
@@ -23,14 +23,17 @@
             'icanhaz',
             'js/application',
             'js/views/Module.view',
+            'properties',
             'js/HandlebarsHelpers',
             'modelbinder',
             'bootstrap',
             'templateConfig'
 
-        ], function ($, Backbone, Marionette, ich, Application, ModuleView) {
+        ], function ($, Backbone, Marionette, ich, Application, ModuleView, Properties) {
 
             var app = Application.App;
+
+            Application.AppModel = new Backbone.Model(Properties);
 
             //setup the area that the modules will load into and asynchronously require in each module
             //so that it can render itself into the area that was just constructed for it
@@ -40,6 +43,9 @@
 
             //setup the header
             app.addInitializer(function() {
+                if(Properties.ui.header && Properties.ui.header !== ''){
+                    $('html').addClass('has-header');
+                }
                 Application.App.headerRegion.show(new Marionette.ItemView({
                     template: 'headerLayout',
                     className: 'header-layout',
@@ -49,6 +55,9 @@
 
             //setup the footer
             app.addInitializer(function() {
+                if(Properties.ui.footer && Properties.ui.footer !== ''){
+                    $('html').addClass('has-footer');
+                }
                 Application.App.footerRegion.show(new Marionette.ItemView({
                     template: 'footerLayout',
                     className: 'footer-layout',

--- a/ui/src/main/webapp/properties.js
+++ b/ui/src/main/webapp/properties.js
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+/*global define*/
+
+define(function (require) {
+    'use strict';
+    var $ = require('jquery');
+
+    var properties = {
+
+        ui: { /* empty until loaded from ajax */},
+
+        init : function(){
+            // use this function to initialize variables that rely on others
+            var props = this;
+            $.ajax({
+                async: false, // must be synchronous to guarantee that no tests are run before fixture is loaded
+                cache: false,
+                dataType: 'json',
+                url: "/services/platform/config/ui"
+            }).success(function(uiConfig) {
+                props.ui = uiConfig;
+                return props;
+
+            }).fail(function(jqXHR, status, errorThrown) {
+                if(console){
+                    console.log('Platform UI Configuration could not be loaded: (status: ' + status + ', message: ' + errorThrown.message + ')');
+                }
+            });
+
+            return props;
+        }
+    };
+
+    return properties.init();
+});

--- a/ui/src/main/webapp/templates/footer.handlebars
+++ b/ui/src/main/webapp/templates/footer.handlebars
@@ -13,8 +13,8 @@
  --}}
 <div class="footer-container">
     <div class="banner-container">
-        <div class="{{style}} {{textColor}}">
-            {{text}}
+        <div style="color: {{ui.color}}; background-color: {{ui.background}}">
+            {{ui.footer}}
         </div>
     </div>
 </div>

--- a/ui/src/main/webapp/templates/header.handlebars
+++ b/ui/src/main/webapp/templates/header.handlebars
@@ -13,8 +13,8 @@
  --}}
 <div class="header-container">
     <div class="banner-container">
-        <div class="{{style}} {{textColor}}">
-            {{text}}
+        <div style="color: {{ui.color}}; background-color: {{ui.background}}">
+            {{ui.header}}
         </div>
     </div>
 </div>


### PR DESCRIPTION
-header and footer are optional in the ui.
-This is a more css based approach since we have relative containers on the page.  I added a div wrapper around all non-banner content to help aid in positioning the main content in between the banners if they are enabled.
-added banner less file to handle everything banner related.
-added properties file to mimic implementation in the search ui.  Also will be handy later for admin-wide properties (which we should start using).
