### PR TITLE
DDF-1202 Updating configuration deletion to properly clear, simplifying logic of new configurations

### DIFF
--- a/ui/src/main/webapp/js/models/Service.js
+++ b/ui/src/main/webapp/js/models/Service.js
@@ -133,35 +133,42 @@ define(['backbone', 'jquery','backboneassociations'],function (Backbone, $) {
             return deferred;
         },
         destroy: function() {
-            var deferred = $.Deferred(),
-                model = this;
-            var deleteUrl = [model.configUrl, "delete", model.get('properties').get("service.pid")].join("/");
+            var deleteUrl = [
+                this.configUrl,
+                "delete",
+                this.get('properties').get("service.pid")
+            ].join("/");
 
             return $.ajax({
                 type: 'GET',
                 url: deleteUrl
-            }).done(function (result) {
-                  deferred.resolve(result);
-                }).fail(function (error) {
-                    deferred.fail(error);
-                });
+            });
+        },
+        initializeFromModel: function (model) {
+            if (model.get("factory")) {
+                return this.initializeFromMSF(model);
+            } else {
+                return this.initializeFromService(model);
+            }
         },
         initializeFromMSF: function(msf) {
-            this.set({"fpid":msf.get("id")});
-            this.set({"name":msf.get("name")});
-            this.get('properties').set({"service.factoryPid": msf.get("id")});
-            this.initializeFromService(msf);
+            this.set({"fpid": msf.get("id")})
+                .set({"name": msf.get("name")});
+            this.get('properties')
+                .set({"service.factoryPid": msf.get("id")});
+            return this.initializeFromService(msf);
         },
         initializeFromService: function(service) {
-            this.initializeFromMetatype(service.get("metatype"));
+            return this.initializeFromMetatype(service.get("metatype"));
         },
         initializeFromMetatype: function(metatype) {
-            var model = this;
+            var properties = this.get('properties');
             metatype.forEach(function(obj){
                 var id = obj.get('id');
                 var val = obj.get('defaultValue');
-                model.get('properties').set(id, (val) ? val.toString() : null);
+                properties.set(id, (val) ? val.toString() : null);
             });
+            return this;
         }
     });
 

--- a/ui/src/main/webapp/js/models/Service.js
+++ b/ui/src/main/webapp/js/models/Service.js
@@ -152,22 +152,25 @@ define(['backbone', 'jquery','backboneassociations'],function (Backbone, $) {
             }
         },
         initializeFromMSF: function(msf) {
-            this.set({"fpid": msf.get("id")})
-                .set({"name": msf.get("name")});
+            var fpid = msf.get("id");
+            this.set({
+                "fpid": fpid,
+                "name": msf.get("name")
+            });
             this.get('properties')
-                .set({"service.factoryPid": msf.get("id")});
+                .set({"service.factoryPid": fpid});
             return this.initializeFromService(msf);
         },
         initializeFromService: function(service) {
             return this.initializeFromMetatype(service.get("metatype"));
         },
         initializeFromMetatype: function(metatype) {
-            var properties = this.get('properties');
-            metatype.forEach(function(obj){
-                var id = obj.get('id');
-                var val = obj.get('defaultValue');
-                properties.set(id, (val) ? val.toString() : null);
-            });
+            this.get('properties')
+                .set(metatype.reduce(function (defaults, obj) {
+                    var val = obj.get('defaultValue');
+                    defaults[obj.get('id')] = (val) ? val.toString() : null;
+                    return defaults;
+                }, {}));
             return this;
         }
     });


### PR DESCRIPTION
- Service.view.js:
  - Updated the "remove configuration" method to wait for the delete to happen, then to refresh the configurations and close.
  - Refactored the "new configuration" method to be much more straightforward.  The previous logic was convoluted.
- Service.js:
  - Updated the "destroy" method to not have a useless Deferred, reformatted the deleteUrl for readability, removed useless done and fail functions from the request.
  - Added the "initialize from model" method, so that you can pass in a model and have it determine how to initialize.
  - Updated the other "initialize from" type methods so that they would return a reference to "this", so method chaining is possible.
  - Various changes to utilize method chaining / optimize.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/codice/ddf-admin/79)

<!-- Reviewable:end -->
