### PR TITLE
DDF-1212 Fixed issue with backbone models, updated incorrect reference

### DIFF
--- a/ui/src/main/webapp/js/models/ApplicationsLayout.js
+++ b/ui/src/main/webapp/js/models/ApplicationsLayout.js
@@ -37,9 +37,11 @@ define([
     // installed. This node can have zero or more children (which are also 'Applications.Treenode`
     // nodes themselves).
     Applications.TreeNode = Backbone.Model.extend({
-        defaults: {
-            chosenApp: false,
-            selected: false
+        defaults: function () {
+            return {
+                chosenApp: false,
+                selected: false
+            };
         },
 
         initialize: function(){

--- a/ui/src/main/webapp/js/models/Installer.js
+++ b/ui/src/main/webapp/js/models/Installer.js
@@ -53,18 +53,20 @@ define([
         url: '/jolokia/exec/org.apache.karaf:type=features,name=root/',
         installUrl:'/jolokia/exec/org.apache.karaf:type=features,name=root/installFeature(java.lang.String)/',
         uninstallUrl: '/jolokia/exec/org.apache.karaf:type=features,name=root/uninstallFeature(java.lang.String)/',
-        defaults: {
-            hasNext: true,
-            hasPrevious: false,
-            totalSteps: 4,
-            stepNumber: 0,
-            percentComplete: 0,
-            busy: false,
-            message: '',
-            steps: [],
-            showInstallProfileStep: false,
-            selectedProfile: null,
-            isCustomProfile: false
+        defaults: function () {
+            return {
+                hasNext: true,
+                hasPrevious: false,
+                totalSteps: 4,
+                stepNumber: 0,
+                percentComplete: 0,
+                busy: false,
+                message: '',
+                steps: [],
+                showInstallProfileStep: false,
+                selectedProfile: null,
+                isCustomProfile: false
+            };
         },
         initialize: function() {
             _.bindAll(this);

--- a/ui/src/main/webapp/js/models/Service.js
+++ b/ui/src/main/webapp/js/models/Service.js
@@ -32,8 +32,10 @@ define(['backbone', 'jquery','backboneassociations'],function (Backbone, $) {
     Service.Configuration = Backbone.AssociatedModel.extend({
         configUrl: "/jolokia/exec/org.codice.ddf.ui.admin.api.ConfigurationAdmin:service=ui,version=2.3.0",
 
-        defaults: {
-            properties: new Service.Properties()
+        defaults: function () {
+            return {
+                properties: new Service.Properties()
+            };
         },
 
         relations: [
@@ -172,9 +174,11 @@ define(['backbone', 'jquery','backboneassociations'],function (Backbone, $) {
     Service.Model = Backbone.AssociatedModel.extend({
         configUrl: "/jolokia/exec/org.codice.ddf.ui.admin.api.ConfigurationAdmin:service=ui,version=2.3.0",
 
-        defaults: {
-            configurations: new Service.ConfigurationList()
-        }, 
+        defaults: function () {
+            return {
+                configurations: new Service.ConfigurationList()
+            };
+        },
 
 
         relations: [

--- a/ui/src/main/webapp/js/views/configuration/Service.view.js
+++ b/ui/src/main/webapp/js/views/configuration/Service.view.js
@@ -53,7 +53,7 @@ define([
             wreqr.vent.trigger('refresh');
         },
         removeConfiguration: function() {
-            var question = "Are you sure you want to remove the configuration: "+this.model.get("service.pid")+"?";
+            var question = "Are you sure you want to remove the configuration: "+this.model.get('properties').get("service.pid")+"?";
             var confirmation = window.confirm(question);
             if(confirmation) {
                 this.model.destroy();


### PR DESCRIPTION
- ApplicationsLayout.js, Installer.js, Service.js:
  - Changed model 'defaults' to use an anonymous function rather than an object.  Using an object caused the reference to be shared among all instances (for example, each time you opened a configuration modal, the configuration would merge with the previously opened configuration causing all sorts of issues upon editing and saving).
- Service.view.js:
  - Updated model reference to be correct (previously it would just be undefined).

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/codice/ddf-admin/80)

<!-- Reviewable:end -->
