### PR TITLE
DDF-1267 Updating how configurables with cardinality > 1 (lists) are saved

### DIFF
--- a/ui/src/main/webapp/js/views/configuration/ConfigurationEdit.view.js
+++ b/ui/src/main/webapp/js/views/configuration/ConfigurationEdit.view.js
@@ -118,7 +118,7 @@ define([
             _.each(this.collectionArray.models, function(model) {
                 values.push(model.get('value'));
             });
-            this.configuration.get('properties').set(this.model.get('id'), values.join());
+            this.configuration.get('properties').set(this.model.get('id'), values);
         },
         onRender: function() {
             this.listItems.show(new ConfigurationEditView.ConfigurationMultiValueCollection({


### PR DESCRIPTION
- Updated 'saveValues' method for MultiValuedItems to save their values as an array rather than a string.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/codice/ddf-admin/89)

<!-- Reviewable:end -->
